### PR TITLE
Using 'text/html' prevents local file from including html tags

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -277,7 +277,7 @@ var saveTextAs = saveTextAs
         }
 
         var doc = saveTxtWindow.document;
-        doc.open('text/plain', 'replace');
+        doc.open('text/html', 'replace');
         doc.charset = charset;
         if (fileName.endsWithAny('.htm', '.html')) {
             doc.close();


### PR DESCRIPTION
When using saveTextAs in IE9 I noticed that HTML tags (<! DOCTYPE ....>, etc...) were included. By changing 'text/plain' to 'text/html' the output ends up just being the text.
